### PR TITLE
Fix reference links in docstrings

### DIFF
--- a/aix360/algorithms/rbm/BRCG.py
+++ b/aix360/algorithms/rbm/BRCG.py
@@ -10,7 +10,7 @@ class BRCGExplainer(DISExplainer):
     normal form (DNF) or conjunctive normal form (CNF) using column generation (CG) [#NeurIPS2018]_.
 
     References:
-        .. [#NeurIPS2018] S. Dash, O. Günlük, D. Wei, "Boolean decision rules via
+        .. [#NeurIPS2018] `S. Dash, O. Günlük, D. Wei, "Boolean decision rules via
            column generation." Neural Information Processing Systems (NeurIPS), 2018.
            <https://papers.nips.cc/paper/7716-boolean-decision-rules-via-column-generation.pdf>`_
     """

--- a/aix360/algorithms/rbm/GLRM.py
+++ b/aix360/algorithms/rbm/GLRM.py
@@ -10,7 +10,7 @@ class GLRMExplainer(DISExplainer):
     * **Logistic Rule Regression:** logistic regression on rule-based features [#Icml2019]_.
 
     References:
-        .. [#Icml2019] D. Wei, S. Dash, T. Gao, O. Günlük, "Generalized linear rule
+        .. [#Icml2019] `D. Wei, S. Dash, T. Gao, O. Günlük, "Generalized linear rule
            models." International Conference on Machine Learning (ICML), 2019.
            <http://proceedings.mlr.press/v97/wei19a/wei19a.pdf>`_
     """


### PR DESCRIPTION
BRCG and GLRM were missing a backtick (`) before the link. Now the link should render properly.