### PR TITLE
Improving Scikit-learn compatability through inheriting appropriate base classes

### DIFF
--- a/aix360/algorithms/rbm/boolean_rule_cg.py
+++ b/aix360/algorithms/rbm/boolean_rule_cg.py
@@ -3,11 +3,12 @@ import numpy as np
 import pandas as pd
 import cvxpy as cvx
 from sklearn.metrics import confusion_matrix, accuracy_score
+from sklearn.base import BaseEstimator, ClassifierMixin
 
 from .beam_search import beam_search, beam_search_K1
 
 
-class BooleanRuleCG(object):
+class BooleanRuleCG(BaseEstimator, ClassifierMixin):
     """BooleanRuleCG is a directly interpretable supervised learning method
     for binary classification that learns a Boolean rule in disjunctive
     normal form (DNF) or conjunctive normal form (CNF) using column generation (CG).

--- a/aix360/algorithms/rbm/linear_regression.py
+++ b/aix360/algorithms/rbm/linear_regression.py
@@ -1,13 +1,15 @@
 import numpy as np
 import pandas as pd
 from sklearn.linear_model import Lasso, Ridge
+from sklearn.base import BaseEstimator, RegressorMixin
+
 
 import matplotlib.pyplot as plt
 
 from .beam_search import beam_search_K1
 
 
-class LinearRuleRegression(object):
+class LinearRuleRegression(BaseEstimator, RegressorMixin):
     """Linear Rule Regression is a directly interpretable supervised learning
     method that performs linear regression on rule-based features.
     """

--- a/aix360/algorithms/rbm/logistic_regression.py
+++ b/aix360/algorithms/rbm/logistic_regression.py
@@ -2,11 +2,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
+from sklearn.base import BaseEstimator, ClassifierMixin
 
 from .beam_search import beam_search_K1
 
 
-class LogisticRuleRegression(object):
+class LogisticRuleRegression(BaseEstimator, ClassifierMixin):
     """Logistic Rule Regression is a directly interpretable supervised learning
     method that performs logistic regression on rule-based features.
     """


### PR DESCRIPTION
Scikit-learn requires that custom estimators have certain functions before they can utilize Scikit-learn's extensive capabilities. For example, `GridSearchCV` requires custom estimators to have the `get_params()` function implemented. This can be done easily by having the custom estimator inherit from Scikit-learn's base classes (Namely, `BaseEstimator` and one of the `ClassifierMixin` or `RegressorMixin` classes for the estimator's appropriate type). The changes proposed in this pull request do exactly this for the following classes:

- LogisticRuleRegression

- LinearRuleRegression

- BooleanRuleCG

This pull request is related to [issue # 63]( https://github.com/IBM/AIX360/issues/63)