### PR TITLE
Changed LICENSE to LICENSE-BSD and add a LICENSE-BSD file

### DIFF
--- a/aix360/algorithms/contrastive/CEM_MAF_aen_PN.py
+++ b/aix360/algorithms/contrastive/CEM_MAF_aen_PN.py
@@ -8,7 +8,7 @@
 ## Copyright (C) 2016, Nicholas Carlini <nicholas@carlini.com>.
 ##
 ## This program is licenced under the BSD 2-Clause licence,
-## contained in the LICENCE file in this directory.
+## contained in the LICENCE-BSD file in this directory.
 
 import sys
 import tensorflow as tf

--- a/aix360/algorithms/contrastive/CEM_MAF_aen_PP.py
+++ b/aix360/algorithms/contrastive/CEM_MAF_aen_PP.py
@@ -8,7 +8,7 @@
 ## Copyright (C) 2016, Nicholas Carlini <nicholas@carlini.com>.
 ##
 ## This program is licenced under the BSD 2-Clause licence,
-## contained in the LICENCE file in this directory.
+## contained in the LICENCE-BSD file in this directory.
 
 import sys, os
 import tensorflow as tf

--- a/aix360/algorithms/contrastive/CEM_MAF_utils.py
+++ b/aix360/algorithms/contrastive/CEM_MAF_utils.py
@@ -1,4 +1,4 @@
-## Utils.py -- Some utility functions 
+## Utils.py -- Some utility functions
 ##
 ## Copyright (C) 2018, PaiShun Ting <paishun@umich.edu>
 ##                     Chun-Chen Tu <timtu@umich.edu>
@@ -7,7 +7,7 @@
 ## Copyright (C) 2016, Nicholas Carlini <nicholas@carlini.com>.
 ##
 ## This program is licenced under the BSD 2-Clause licence,
-## contained in the LICENCE file in this directory.
+## contained in the LICENCE-BSD file in this directory.
 
 import tensorflow as tf
 import os
@@ -50,7 +50,7 @@ class CELEBAModel:
         self.image_size = 224
         self.num_channels = 3
         self.num_labels = 8
-    
+
         input_layer = Input(shape=(self.image_size, self.image_size, self.num_channels))
         weights = "imagenet" if use_imagenet_pretrain else None
         if nn_type == "resnet50":
@@ -68,17 +68,17 @@ class CELEBAModel:
         if use_softmax:
             x = Activation("softmax")(x)
         model = Model(inputs=base_model.input, outputs=x)
-    
+
         # for layer in base_model.layers:
         # 	layer.trainable = False
-    
-    
+
+
         if restore:
             print("Load: {}".format(restore))
             model.load_weights(restore)
-    
+
         self.model = model
-    
+
     def predict(self, data):
         # this is used inside tf session, data should be a tensor
         return self.model(data)

--- a/aix360/algorithms/contrastive/LICENSE-BSD.txt
+++ b/aix360/algorithms/contrastive/LICENSE-BSD.txt
@@ -1,0 +1,21 @@
+LICENSE
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Fixing licensing for CEM-MAF.  There still needs to be a comment in a file in AIX360 directory to say that the LICENSE there does not apply to files in AIX360\aix360\algorithms\contrastive which are rather bound to the LICENSE-BSD file in that directory.