### PR TITLE
shap version 0.34.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - python3.6 ./tests/rbm/test_Linear_Rule_Regression.py
   - python3.6 ./tests/rbm/test_Logistic_Rule_Regression.py
   - python3.6 ./tests/lime/test_lime.py
-#  - python3.6 ./tests/shap/test_shap.py
+  - python3.6 ./tests/shap/test_shap.py
 
 after_success:
 #  - codecov

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
             'scikit-image',
             'requests',
             'lime',
-            'shap',
+            'shap==0.34.0',
             'xgboost', 
 	    'bleach>=2.1.0',
 	    'docutils>=0.13.1',


### PR DESCRIPTION
Few incompatibilities related to DeepExplainer in shap version 0.35.0 due to tensorflow issues, explicitly specified shap version number in setup.py